### PR TITLE
adding commutes method to QubitSparsePauli

### DIFF
--- a/crates/accelerate/src/pauli_lindblad_map/qubit_sparse_pauli.rs
+++ b/crates/accelerate/src/pauli_lindblad_map/qubit_sparse_pauli.rs
@@ -617,7 +617,7 @@ impl QubitSparsePauli {
         }
     }
 
-    // Check if self commutes with other
+    // Check if `self` commutes with `other`
     pub fn commutes(&self, other: &QubitSparsePauli) -> Result<bool, ArithmeticError> {
         if self.num_qubits != other.num_qubits {
             return Err(ArithmeticError::MismatchedQubits {

--- a/crates/accelerate/src/pauli_lindblad_map/qubit_sparse_pauli.rs
+++ b/crates/accelerate/src/pauli_lindblad_map/qubit_sparse_pauli.rs
@@ -616,6 +616,43 @@ impl QubitSparsePauli {
             boundaries: vec![0, self.paulis.len()],
         }
     }
+
+    // Check if self commutes with other
+    pub fn commutes(&self, other: &QubitSparsePauli) -> Result<bool, ArithmeticError> {
+        if self.num_qubits != other.num_qubits {
+            return Err(ArithmeticError::MismatchedQubits {
+                left: self.num_qubits,
+                right: other.num_qubits,
+            });
+        }
+
+        // if either are the identity, return true
+        if self.indices.len() == 0 || other.indices.len() == 0 {
+            return Ok(true);
+        }
+
+        let mut commutes = true;
+
+        let mut self_idx = 0;
+        let mut other_idx = 0;
+
+        // iterate through each entry of self and other one time, incrementing based on the ordering
+        // or equality of self_idx and other_idx, until one of them runs out of entries
+        while self_idx < self.indices.len() && other_idx < other.indices.len() {
+            if self.indices[self_idx] < other.indices[other_idx] {
+                self_idx += 1;
+            } else if self.indices[self_idx] == other.indices[other_idx] {
+                // if the indices are the same, check commutation
+                commutes = commutes == (self.paulis[self_idx] == other.paulis[other_idx]);
+                self_idx += 1;
+                other_idx += 1;
+            } else {
+                other_idx += 1;
+            }
+        }
+
+        Ok(commutes)
+    }
 }
 
 #[derive(Error, Debug)]
@@ -1199,6 +1236,14 @@ impl PyQubitSparsePauli {
 
     fn to_label(&self) -> PyResult<String> {
         Ok(self.inner.view().to_sparse_str())
+    }
+
+    /// Check if self commutes with another :class:`QubitSparsePauli`.
+    ///
+    /// Args:
+    ///     other (QubitSparsePauli): the qubit sparse Pauli to check for commutation with.
+    fn commutes(&self, other: PyQubitSparsePauli) -> PyResult<bool> {
+        Ok(self.inner.commutes(&other.inner)?)
     }
 
     fn __eq__(slf: Bound<Self>, other: Bound<PyAny>) -> PyResult<bool> {

--- a/crates/accelerate/src/pauli_lindblad_map/qubit_sparse_pauli.rs
+++ b/crates/accelerate/src/pauli_lindblad_map/qubit_sparse_pauli.rs
@@ -626,13 +626,7 @@ impl QubitSparsePauli {
             });
         }
 
-        // if either are the identity, return true
-        if self.indices.len() == 0 || other.indices.len() == 0 {
-            return Ok(true);
-        }
-
         let mut commutes = true;
-
         let mut self_idx = 0;
         let mut other_idx = 0;
 
@@ -1238,7 +1232,7 @@ impl PyQubitSparsePauli {
         Ok(self.inner.view().to_sparse_str())
     }
 
-    /// Check if self commutes with another :class:`QubitSparsePauli`.
+    /// Check if `self`` commutes with another qubit sparse pauli.
     ///
     /// Args:
     ///     other (QubitSparsePauli): the qubit sparse Pauli to check for commutation with.

--- a/test/python/quantum_info/test_qubit_sparse_pauli.py
+++ b/test/python/quantum_info/test_qubit_sparse_pauli.py
@@ -394,6 +394,40 @@ class TestQubitSparsePauli(QiskitTestCase):
             strict=True,
         )
 
+    def test_commutes(self):
+        p0 = QubitSparsePauli("XIY")
+        p1 = QubitSparsePauli("IZI")
+        self.assertTrue(p0.commutes(p1))
+        self.assertTrue(p1.commutes(p0))
+
+        p0 = QubitSparsePauli("XXY")
+        p1 = QubitSparsePauli("IZI")
+        self.assertFalse(p0.commutes(p1))
+        self.assertFalse(p1.commutes(p0))
+
+        p0 = QubitSparsePauli("XXY")
+        p1 = QubitSparsePauli("IZX")
+        self.assertTrue(p0.commutes(p1))
+        self.assertTrue(p1.commutes(p0))
+
+        p0 = QubitSparsePauli("XXYY")
+        p1 = QubitSparsePauli("IZXY")
+        self.assertTrue(p0.commutes(p1))
+        self.assertTrue(p1.commutes(p0))
+
+        p0 = QubitSparsePauli("XXYYZ")
+        p1 = QubitSparsePauli("IZXYX")
+        self.assertFalse(p0.commutes(p1))
+        self.assertFalse(p1.commutes(p0))
+
+    def test_commutes_errors(self):
+        p0 = QubitSparsePauli.from_label("XZYI")
+        p1 = QubitSparsePauli.from_label("ZIY")
+        with self.assertRaisesRegex(ValueError, "mismatched numbers of qubits: 4, 3"):
+            p0.commutes(p1)
+        with self.assertRaisesRegex(ValueError, "mismatched numbers of qubits: 3, 4"):
+            p1.commutes(p0)
+
 
 @ddt.ddt
 class TestQubitSparsePauliList(QiskitTestCase):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Adds method `QubitSparsePauli.commutes(other: QubitSparsePauli) -> bool`. 

### Details and comments


