### PR TITLE
Add scale_rates and inverse methods to PauliLindbladMap

### DIFF
--- a/crates/accelerate/src/pauli_lindblad_map/pauli_lindblad_map_class.rs
+++ b/crates/accelerate/src/pauli_lindblad_map/pauli_lindblad_map_class.rs
@@ -264,6 +264,16 @@ impl PauliLindbladMap {
             qubit_sparse_pauli: self.qubit_sparse_pauli_list.term(index),
         }
     }
+
+    pub fn scale_rates(self, scale_factor: f64) -> Self {
+        let new_rates = self.rates.iter().map(|r| scale_factor * r).collect();
+        PauliLindbladMap::new_unchecked(
+            new_rates, 
+            self.qubit_sparse_pauli_list.clone()
+        )
+    }
+
+    pub fn inverse(self) -> 
 }
 
 /// Given a rate, return the corresponding gamma, probability, and boolean for whether the rate is

--- a/crates/accelerate/src/pauli_lindblad_map/pauli_lindblad_map_class.rs
+++ b/crates/accelerate/src/pauli_lindblad_map/pauli_lindblad_map_class.rs
@@ -266,7 +266,7 @@ impl PauliLindbladMap {
     }
 
     /// Scale the rates by a set factor.
-    /// 
+    ///
     /// # Safety
     ///
     /// The coherence of the result is equivalent to the coherence fo Self, and as such there is no
@@ -276,8 +276,8 @@ impl PauliLindbladMap {
         unsafe { PauliLindbladMap::new_unchecked(new_rates, self.qubit_sparse_pauli_list.clone()) }
     }
 
-    /// Invert the map. Labelled unsafe but coherence is assured if self is coherent
-    /// 
+    /// Invert the map.
+    ///
     /// # Safety
     ///
     /// The coherence of the result is equivalent to the coherence fo Self, and as such there is no

--- a/crates/accelerate/src/pauli_lindblad_map/pauli_lindblad_map_class.rs
+++ b/crates/accelerate/src/pauli_lindblad_map/pauli_lindblad_map_class.rs
@@ -265,15 +265,16 @@ impl PauliLindbladMap {
         }
     }
 
-    pub fn scale_rates(self, scale_factor: f64) -> Self {
+    // Scale the rates by a set factor. Labelled unsafe but coherence is assured if self is coherent
+    pub unsafe fn scale_rates(self, scale_factor: f64) -> Self {
         let new_rates = self.rates.iter().map(|r| scale_factor * r).collect();
-        PauliLindbladMap::new_unchecked(
-            new_rates, 
-            self.qubit_sparse_pauli_list.clone()
-        )
+        unsafe { PauliLindbladMap::new_unchecked(new_rates, self.qubit_sparse_pauli_list.clone()) }
     }
 
-    pub fn inverse(self) -> 
+    // Invert the map. Labelled unsafe but coherence is assured if self is coherent
+    pub unsafe fn inverse(self) -> Self {
+        unsafe { self.scale_rates(-1.) }
+    }
 }
 
 /// Given a rate, return the corresponding gamma, probability, and boolean for whether the rate is
@@ -1077,6 +1078,25 @@ impl PyPauliLindbladMap {
             out.append(to_py_tuple(view)?)?;
         }
         Ok(out.unbind())
+    }
+
+    /// Return a new :class:`PauliLindbladMap` with rates scaled by `scale_factor`.
+    ///
+    /// Args:
+    ///     scale_factor (float): the scaling coefficient.
+    #[pyo3(signature = (scale_factor))]
+    fn scale_rates<'py>(&self, py: Python<'py>, scale_factor: f64) -> PyResult<Bound<'py, PyPauliLindbladMap>> {
+        let inner = self.inner.read().map_err(|_| InnerReadError)?;
+        unsafe { 
+            let scaled = inner.clone().scale_rates(scale_factor); 
+            scaled.into_pyobject(py)
+        }
+    }
+
+    /// Return a new :class:`PauliLindbladMap` that is the mathematical inverse of `self`.
+    #[pyo3(signature = ())]
+    fn inverse<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyPauliLindbladMap>> {
+        self.scale_rates(py, -1.)
     }
 
     fn __len__(&self) -> PyResult<usize> {

--- a/crates/accelerate/src/pauli_lindblad_map/pauli_lindblad_map_class.rs
+++ b/crates/accelerate/src/pauli_lindblad_map/pauli_lindblad_map_class.rs
@@ -265,13 +265,23 @@ impl PauliLindbladMap {
         }
     }
 
-    // Scale the rates by a set factor. Labelled unsafe but coherence is assured if self is coherent
+    /// Scale the rates by a set factor.
+    /// 
+    /// # Safety
+    ///
+    /// The coherence of the result is equivalent to the coherence fo Self, and as such there is no
+    /// need to construct the map with the safe PauliLindbladMap::new.
     pub unsafe fn scale_rates(self, scale_factor: f64) -> Self {
         let new_rates = self.rates.iter().map(|r| scale_factor * r).collect();
         unsafe { PauliLindbladMap::new_unchecked(new_rates, self.qubit_sparse_pauli_list.clone()) }
     }
 
-    // Invert the map. Labelled unsafe but coherence is assured if self is coherent
+    /// Invert the map. Labelled unsafe but coherence is assured if self is coherent
+    /// 
+    /// # Safety
+    ///
+    /// The coherence of the result is equivalent to the coherence fo Self, and as such there is no
+    /// need to construct the map with the safe PauliLindbladMap::new.
     pub unsafe fn inverse(self) -> Self {
         unsafe { self.scale_rates(-1.) }
     }
@@ -1085,10 +1095,14 @@ impl PyPauliLindbladMap {
     /// Args:
     ///     scale_factor (float): the scaling coefficient.
     #[pyo3(signature = (scale_factor))]
-    fn scale_rates<'py>(&self, py: Python<'py>, scale_factor: f64) -> PyResult<Bound<'py, PyPauliLindbladMap>> {
+    fn scale_rates<'py>(
+        &self,
+        py: Python<'py>,
+        scale_factor: f64,
+    ) -> PyResult<Bound<'py, PyPauliLindbladMap>> {
         let inner = self.inner.read().map_err(|_| InnerReadError)?;
-        unsafe { 
-            let scaled = inner.clone().scale_rates(scale_factor); 
+        unsafe {
+            let scaled = inner.clone().scale_rates(scale_factor);
             scaled.into_pyobject(py)
         }
     }

--- a/test/python/quantum_info/test_pauli_lindblad_map.py
+++ b/test/python/quantum_info/test_pauli_lindblad_map.py
@@ -707,48 +707,35 @@ class TestPauliLindbladMap(QiskitTestCase):
     def test_scale_rates(self):
         pauli_lindblad_map = PauliLindbladMap([("IXYZXYZXYZ", 1.0)])
         self.assertEqual(
-            pauli_lindblad_map.scale_rates(12.32), 
-            PauliLindbladMap([("IXYZXYZXYZ", 12.32)])
+            pauli_lindblad_map.scale_rates(12.32), PauliLindbladMap([("IXYZXYZXYZ", 12.32)])
         )
 
         pauli_lindblad_map = PauliLindbladMap(
             [("IXYZXYZXYZ", -1.0), ("IXYZXYZXYZ", 1.0), ("IXYZXYZXYZ", -0.5)]
         )
         self.assertEqual(
-            pauli_lindblad_map.scale_rates(3.2), 
-            PauliLindbladMap(
-                [("IXYZXYZXYZ", -3.2), ("IXYZXYZXYZ", 3.2), ("IXYZXYZXYZ", -1.6)]
-            )
+            pauli_lindblad_map.scale_rates(3.2),
+            PauliLindbladMap([("IXYZXYZXYZ", -3.2), ("IXYZXYZXYZ", 3.2), ("IXYZXYZXYZ", -1.6)]),
         )
 
         self.assertEqual(
-            PauliLindbladMap.identity(5).scale_rates(5.),
-            PauliLindbladMap.identity(5)
+            PauliLindbladMap.identity(5).scale_rates(5.0), PauliLindbladMap.identity(5)
         )
 
-    
     def test_inverse(self):
 
         pauli_lindblad_map = PauliLindbladMap([("IXYZXYZXYZ", 1.0)])
-        self.assertEqual(
-            pauli_lindblad_map.inverse(), 
-            PauliLindbladMap([("IXYZXYZXYZ", -1.0)])
-        )
+        self.assertEqual(pauli_lindblad_map.inverse(), PauliLindbladMap([("IXYZXYZXYZ", -1.0)]))
 
         pauli_lindblad_map = PauliLindbladMap(
             [("IXYZXYZXYZ", -1.0), ("IXYZXYZXYZ", 1.0), ("IXYZXYZXYZ", -0.5)]
         )
         self.assertEqual(
-            pauli_lindblad_map.inverse(), 
-            PauliLindbladMap(
-                [("IXYZXYZXYZ", 1.0), ("IXYZXYZXYZ", -1.0), ("IXYZXYZXYZ", 0.5)]
-            )
+            pauli_lindblad_map.inverse(),
+            PauliLindbladMap([("IXYZXYZXYZ", 1.0), ("IXYZXYZXYZ", -1.0), ("IXYZXYZXYZ", 0.5)]),
         )
 
-        self.assertEqual(
-            PauliLindbladMap.identity(5).inverse(),
-            PauliLindbladMap.identity(5)
-        )
+        self.assertEqual(PauliLindbladMap.identity(5).inverse(), PauliLindbladMap.identity(5))
 
 
 def canonicalize_term(pauli, indices, rate):

--- a/test/python/quantum_info/test_pauli_lindblad_map.py
+++ b/test/python/quantum_info/test_pauli_lindblad_map.py
@@ -704,6 +704,52 @@ class TestPauliLindbladMap(QiskitTestCase):
         self.assertTrue(np.allclose(probs, pauli_lindblad_map.probabilities))
         self.assertEqual(gamma, pauli_lindblad_map.gamma)
 
+    def test_scale_rates(self):
+        pauli_lindblad_map = PauliLindbladMap([("IXYZXYZXYZ", 1.0)])
+        self.assertEqual(
+            pauli_lindblad_map.scale_rates(12.32), 
+            PauliLindbladMap([("IXYZXYZXYZ", 12.32)])
+        )
+
+        pauli_lindblad_map = PauliLindbladMap(
+            [("IXYZXYZXYZ", -1.0), ("IXYZXYZXYZ", 1.0), ("IXYZXYZXYZ", -0.5)]
+        )
+        self.assertEqual(
+            pauli_lindblad_map.scale_rates(3.2), 
+            PauliLindbladMap(
+                [("IXYZXYZXYZ", -3.2), ("IXYZXYZXYZ", 3.2), ("IXYZXYZXYZ", -1.6)]
+            )
+        )
+
+        self.assertEqual(
+            PauliLindbladMap.identity(5).scale_rates(5.),
+            PauliLindbladMap.identity(5)
+        )
+
+    
+    def test_inverse(self):
+
+        pauli_lindblad_map = PauliLindbladMap([("IXYZXYZXYZ", 1.0)])
+        self.assertEqual(
+            pauli_lindblad_map.inverse(), 
+            PauliLindbladMap([("IXYZXYZXYZ", -1.0)])
+        )
+
+        pauli_lindblad_map = PauliLindbladMap(
+            [("IXYZXYZXYZ", -1.0), ("IXYZXYZXYZ", 1.0), ("IXYZXYZXYZ", -0.5)]
+        )
+        self.assertEqual(
+            pauli_lindblad_map.inverse(), 
+            PauliLindbladMap(
+                [("IXYZXYZXYZ", 1.0), ("IXYZXYZXYZ", -1.0), ("IXYZXYZXYZ", 0.5)]
+            )
+        )
+
+        self.assertEqual(
+            PauliLindbladMap.identity(5).inverse(),
+            PauliLindbladMap.identity(5)
+        )
+
 
 def canonicalize_term(pauli, indices, rate):
     # canonicalize a sparse list term by sorting by indices (which is unique as


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Adds function `scale_rates` (for scaling the rates by a float) and `inverse` (which scales the rates by `-1.`).

### Details and comments


